### PR TITLE
Add copy/move support for parameter_pack and improve tests

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -79,6 +79,14 @@ jobs:
             vcpkg_triplet: x64-osx
             cxx_standard: "23"
 
+          # macOS Clang - C++23 with Deployment Target 12.0
+          - os: macos-latest
+            compiler: clang
+            cmake_generator: "Unix Makefiles"
+            vcpkg_triplet: x64-osx
+            cxx_standard: "23"
+            osx_deployment_target: "12.0"
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -142,10 +150,16 @@ jobs:
     - name: Configure CMake
       shell: pwsh
       run: |
+        $deploymentTargetArg = ""
+        if ("${{ matrix.osx_deployment_target }}" -ne "") {
+          $deploymentTargetArg = "-DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.osx_deployment_target }}"
+        }
+
         cmake -S . -B build `
           -G "${{ matrix.cmake_generator }}" `
           -DCMAKE_BUILD_TYPE=Release `
           -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} `
+          $deploymentTargetArg `
           -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" `
           -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -180,7 +180,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.compiler }}-cpp${{ matrix.cxx_standard }}
+        name: test-results-${{ matrix.os }}-${{ matrix.compiler }}-cpp${{ matrix.cxx_standard }}${{ matrix.osx_deployment_target && format('-macos{0}', matrix.osx_deployment_target) || '' }}
         path: |
           build/Testing/
           build/**/test-results.xml

--- a/include/storage/heterogeneous_container.h
+++ b/include/storage/heterogeneous_container.h
@@ -400,7 +400,7 @@ private:
 					{
 						_insert(std::forward<decltype(tupleArgs)>(tupleArgs)...);
 					},
-					value);
+					std::forward<decltype(value)>(value));
 			}
 			else if constexpr (constraints::is_initializer_list_v<_T>)
 			{


### PR DESCRIPTION
- Defaulted copy/move constructors and assignment for parameter_pack
- Enhanced _insert to handle nested parameter_pack and tuples correctly
- Fixed tuple forwarding in heterogeneous_container
- Added comprehensive unit tests for copy/move semantics and nesting
- Updated CI to support macOS Clang with deployment target 12.0+